### PR TITLE
Fix imports for mapbox: 3.7.0 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,5 @@
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 
-import * as Constants from '@mapbox/mapbox-gl-draw/src/constants';
-import doubleClickZoom from '@mapbox/mapbox-gl-draw/src/lib/double_click_zoom';
-import createSupplementaryPoints from '@mapbox/mapbox-gl-draw/src/lib/create_supplementary_points';
-import * as CommonSelectors from '@mapbox/mapbox-gl-draw/src/lib/common_selectors';
-import moveFeatures from '@mapbox/mapbox-gl-draw/src/lib/move_features';
-
 import {lineString, point} from '@turf/helpers';
 import bearing from '@turf/bearing';
 // import centroid from '@turf/centroid';
@@ -15,6 +9,14 @@ import distance from '@turf/distance';
 import destination from '@turf/destination';
 import transformRotate from '@turf/transform-rotate';
 import transformScale from '@turf/transform-scale';
+
+const Constants = MapboxDraw.constants;
+const {
+    doubleClickZoom,
+    createSupplementaryPoints,
+    CommonSelectors,
+    moveFeatures,
+  } = MapboxDraw.lib;
 
 export const TxRectMode = {};
 


### PR DESCRIPTION
Address the issues raised in #39. Update Mapbox imports 